### PR TITLE
Code review

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1,7 +1,6 @@
 use chrono::prelude::{DateTime, Local};
-use std::cmp::PartialEq;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 /// Contains useful information on a client which is connected to the openvpn server
 pub struct Client {
     name: String,
@@ -29,12 +28,12 @@ impl Client {
     }
 
     /// Common Name
-    pub fn name(&self) -> &String {
+    pub fn name(&self) -> &str {
         &self.name
     }
 
     /// Remote IP address
-    pub fn ip_address(&self) -> &String {
+    pub fn ip_address(&self) -> &str {
         &self.ip_address
     }
 
@@ -44,22 +43,12 @@ impl Client {
     }
 
     /// Bytes received from the client
-    pub fn bytes_received(&self) -> &f64 {
-        &self.bytes_received
+    pub fn bytes_received(&self) -> f64 {
+        self.bytes_received
     }
 
     /// Bytes sent to remote servers
-    pub fn bytes_sent(&self) -> &f64 {
-        &self.bytes_sent
-    }
-}
-
-impl PartialEq for Client {
-    fn eq(&self, other: &Client) -> bool {
-        self.name == other.name
-            && self.ip_address == other.ip_address
-            && self.bytes_received == other.bytes_received
-            && self.bytes_sent == other.bytes_sent
-            && self.connected_since == other.connected_since
+    pub fn bytes_sent(&self) -> f64 {
+        self.bytes_sent
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,7 +61,7 @@ pub struct Status {
 }
 
 impl Status {
-    pub fn clients(&self) -> &Vec<Client> {
+    pub fn clients(&self) -> &[Client] {
         &self.clients
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,19 +147,18 @@ fn parse_status_output(output: String) -> Result<Vec<Client>> {
 }
 
 fn parse_client(raw_client: &str) -> Result<Client> {
-    let split = raw_client.split('\t');
-    let vec = split.collect::<Vec<&str>>();
+    let vec: Vec<_> = raw_client.split('\t').collect();
     if vec.len() < 9 {
         return Err(OpenvpnError::MalformedResponse(raw_client.to_string()));
     }
     let name = vec[1];
-    let address = match vec[2].split(':').next() {
-        Some(a) => a,
-        None => return Err(OpenvpnError::MalformedResponse(raw_client.to_string())),
-    };
-    let timestamp = vec[8].parse::<i64>()?;
-    let bytes_received = vec[5].parse::<f64>()?;
-    let bytes_sent = vec[6].parse::<f64>()?;
+    let address = vec[2]
+        .split(':')
+        .next()
+        .ok_or_else(|| OpenvpnError::MalformedResponse(raw_client.to_string()))?;
+    let timestamp: i64 = vec[8].parse()?;
+    let bytes_received: f64 = vec[5].parse()?;
+    let bytes_sent: f64 = vec[6].parse()?;
     Ok(Client::new(
         String::from(name),
         String::from(address),
@@ -170,6 +169,5 @@ fn parse_client(raw_client: &str) -> Result<Client> {
 }
 
 fn get_local_start_time(timestamp: i64) -> DateTime<Local> {
-    let datetime: DateTime<Local> = Local.timestamp(timestamp, 0);
-    datetime
+    Local.timestamp(timestamp, 0)
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -7,18 +7,15 @@ use std::thread;
 
 fn setup_tcp_server(port: u16, response: &'static str) -> thread::JoinHandle<()> {
     let mut connection_string = "localhost:".to_string();
-    connection_string.push_str(&mut port.to_string());
+    connection_string.push_str(&port.to_string());
     let listener = TcpListener::bind(connection_string).unwrap();
     thread::spawn(move || {
-        for client_stream in listener.incoming() {
-            let mut stream = client_stream.unwrap();
-            let mut reader = BufReader::new(&stream);
-            let mut output = String::new();
-            reader.read_line(&mut output).unwrap();
-            assert_eq!("status\n".to_string(), output);
-            stream.write(response.as_bytes()).unwrap();
-            break;
-        }
+        let mut stream = listener.accept().unwrap().0;
+        let mut reader = BufReader::new(&stream);
+        let mut output = String::new();
+        reader.read_line(&mut output).unwrap();
+        assert_eq!("status\n".to_string(), output);
+        stream.write_all(response.as_bytes()).unwrap();
     })
 }
 
@@ -86,7 +83,7 @@ fn test_client_details_too_short_in_response() {
 #[test]
 fn test_client_correct_details_in_response() {
     let server_response = "\nHEADER\tCLIENT_LIST\nCLIENT_LIST\ttest-client\t127.0.0.1:12345\t10.8.0.2\t\t100\t200\tdate-string\t1546277714\nEND";
-    let expected_client = new_mock_client("test-client", "127.0.0.1", 1546277714, 100.0, 200.0);
+    let expected_client = new_mock_client("test-client", "127.0.0.1", 1_546_277_714, 100.0, 200.0);
     let handle = setup_tcp_server(5555, server_response);
     let mut api = openvpn_management::CommandManagerBuilder::new().build();
     let status_response = api.get_status();
@@ -105,14 +102,14 @@ fn test_multiple_clients_details() {
     expected_clients.push(new_mock_client(
         "test-client",
         "127.0.0.1",
-        1546277714,
+        1_546_277_714,
         100.0,
         200.0,
     ));
     expected_clients.push(new_mock_client(
         "test-client2",
         "192.168.0.3",
-        1546277715,
+        1_546_277_715,
         300.0,
         400.0,
     ));

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -119,7 +119,7 @@ fn test_multiple_clients_details() {
     let status_response = api.get_status();
     assert!(status_response.is_ok());
     let status = status_response.unwrap();
-    assert_eq!(&expected_clients, status.clients());
+    assert_eq!(expected_clients.as_slice(), status.clients());
     handle.join().unwrap();
 }
 


### PR DESCRIPTION
Hey, I came from your post on /r/rust. I have some changes to suggest. They're pretty much all small things that are just matters of style. I also changed the types of some accessors. When you are returning a `Copy` type you don't have to return a reference. Also, you usually want to return `&[T]` and `&str` rather than `&Vec<T>` and `&String`. Also, the choice to have `CommandManagerBuilder` for just one parameter seems rather strange, unless you plan on adding a lot more options, but I didn't change anything about that. Another thing to look is that the preferred style of comments in rust is to always use single line comments (I'm not sure on the reasoning, but it seems very widespread).